### PR TITLE
updates dep example with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ by adding `map_diff` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:map_diff, "~> 1.0"}]
+  [{:map_diff, "~> 1.3"}]
 end
 ```
 


### PR DESCRIPTION
While looking through the readme I noticed the example is out of date with hex. This patch fixes it.